### PR TITLE
Feature: Allow to force language list to display

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -3,6 +3,7 @@
 $english = array(
 
 	'language_selector:admin:settings:min_completeness' => 'Minimum language completeness (e.g. 30)',
+	'language_selector:admin:settings:force_languages' => 'Only allow the following languages (e.g. fr,en,es,de)',
 	'language_selector:admin:settings:show_in_header' => 'Show language selector in header?',
 	'language_selector:admin:settings:autodetect' => 'Enable autodetect of language (for non-logged in users)',
 	'language_selector:admin:settings:show_images' => 'Show images of language/country (if available)',

--- a/languages/fr.php
+++ b/languages/fr.php
@@ -3,6 +3,7 @@
 $french = array(
 
 	'language_selector:admin:settings:min_completeness' => "Quel est le pourcentage minimum d'exhaustivité d'une langue pour qu'elle puisse apparaître dans le sélecteur de langue (ex 30)",
+	'language_selector:admin:settings:force_languages' => "N'afficher que les langues suivantes (ex: fr,en,es,de)",
 	'language_selector:admin:settings:show_in_header' => "Afficher les langues disponibles dans l'entête",
 	'language_selector:admin:settings:autodetect' => "Activer la détection automatique de la langue (pour les utilisateurs non connectés)",
 	'language_selector:admin:settings:show_images' => "Afficher le drapeau du pays (si disponible)",

--- a/languages/nl.php
+++ b/languages/nl.php
@@ -3,6 +3,7 @@
 $dutch = array(
 
 	'language_selector:admin:settings:min_completeness' => 'Minimum taalcompleetheidspercentage (bijv. 30)',
+	'language_selector:admin:settings:force_languages' => 'Only allow the following languages (bijv. fr,en,es,de)',
 	'language_selector:admin:settings:show_in_header' => 'Toon de language selector in de header?',
 	'language_selector:admin:settings:autodetect' => 'Activeer automatische detectie van browser taal (voor niet aangemelde gebruikers)',
 	'language_selector:admin:settings:show_images' => 'Toon afbeelding van vlag van land (indien beschikbaar)',

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -10,8 +10,12 @@
  * @return array
  */
 function language_selector_get_allowed_translations() {
-	
-	$configured_allowed = elgg_get_plugin_setting("allowed_languages", "language_selector");
+	$forced_languages = elgg_get_plugin_setting("force_languages", "language_selector");
+	if (empty($forced_languages)) {
+		$configured_allowed = elgg_get_plugin_setting("allowed_languages", "language_selector");
+	} else {
+		$configured_allowed = $forced_languages;
+	}
 	
 	if (empty($configured_allowed)) {
 		$allowed = array("en");

--- a/views/default/plugins/language_selector/settings.php
+++ b/views/default/plugins/language_selector/settings.php
@@ -18,6 +18,14 @@ $noyes_options = array_reverse($yesno_options);
 	</tr>
 	<tr>
 		<td>
+			<?php echo elgg_echo("language_selector:admin:settings:force_languages"); ?><br />
+		</td>
+		<td>
+			<?php echo elgg_view("input/text", array("name" => "params[force_languages]", "value" => $vars['entity']->force_languages, "size" => 200, "maxlength" => 200)); ?>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<?php echo elgg_echo('language_selector:admin:settings:show_in_header'); ?>
 		</td>
 		<td>


### PR DESCRIPTION
I needed to be able to force only certain languages for my site, and not match them from their completeness - which seems highly unreliable.
This new feature lets a user set the list of language country codes it wants - and only that one - to display

I don't know nl so I've let the english sentence there :)
