### PR TITLE
Upgrade to Elgg 3

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -1,6 +1,6 @@
 <?php
 
-$english = array(
+return array(
 
 	'language_selector:admin:settings:min_completeness' => 'Minimum language completeness (e.g. 30)',
 	'language_selector:admin:settings:show_in_header' => 'Show language selector in header?',
@@ -8,5 +8,3 @@ $english = array(
 	'language_selector:admin:settings:show_images' => 'Show images of language/country (if available)',
 	'language_selector:change' => 'Change language',
 );
-				
-add_translation("en",$english);

--- a/languages/fr.php
+++ b/languages/fr.php
@@ -1,6 +1,6 @@
-<?php
+r<?php
 
-$french = array(
+return array(
 
 	'language_selector:admin:settings:min_completeness' => "Quel est le pourcentage minimum d'exhaustivité d'une langue pour qu'elle puisse apparaître dans le sélecteur de langue (ex 30)",
 	'language_selector:admin:settings:show_in_header' => "Afficher les langues disponibles dans l'entête",
@@ -8,5 +8,3 @@ $french = array(
 	'language_selector:admin:settings:show_images' => "Afficher le drapeau du pays (si disponible)",
 
 );
-
-add_translation("fr",$french);

--- a/languages/fr.php
+++ b/languages/fr.php
@@ -1,4 +1,4 @@
-r<?php
+<?php
 
 return array(
 

--- a/languages/nl.php
+++ b/languages/nl.php
@@ -1,6 +1,6 @@
 <?php
 
-$dutch = array(
+return array(
 
 	'language_selector:admin:settings:min_completeness' => 'Minimum taalcompleetheidspercentage (bijv. 30)',
 	'language_selector:admin:settings:show_in_header' => 'Toon de language selector in de header?',
@@ -8,5 +8,3 @@ $dutch = array(
 	'language_selector:admin:settings:show_images' => 'Toon afbeelding van vlag van land (indien beschikbaar)',
 
 );
-				
-add_translation("nl",$dutch);


### PR DESCRIPTION
I've been looking at setting up a Elgg3 instance as as prototype and I need a language selector.

I've changed the formatting of the language files so that I don't get an error when activating the plugin.

But when I set `Show language selector in header?` to yes, it doesn't show.  I can look at making the changes if you could point me in the right direction